### PR TITLE
compat: bump stoffelcrypto (mpc-protocols) and stoffelnet to 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the Stoffel crates are tracked here.
 
+## [Unreleased]
+
+### Changed
+
+- Bumped `stoffelcrypto` (mpc-protocols) to `0.1.1` and `stoffelnet` to `0.1.1` across the workspace and coordinator wrapper. `stoffelmpc-network` follows to `0.1.1` via the lockfile. `stoffel-mpc-coordinator-shared` and `stoffel-mpc-coordinator-off-chain` remain on `0.1.0`.
+- Adapted the AVSS engine to the `stoffelcrypto` 0.1.1 API: `verify_feldman` now takes an `expected_id`, and the AVSS share store values carry a receive timestamp alongside the shares. Existing verification semantics are preserved by binding shares to their own embedded evaluation id.
+
 ## [0.1.2] - 2026-09-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5886,9 +5886,9 @@ dependencies = [
 
 [[package]]
 name = "stoffelcrypto"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5dea6e2e0db0ec0ca2c66f03ea43f8054c0440c77dcc791c5e4b97d072fa7e5"
+checksum = "a66dfe8e28c5d20fb9f4864b68f67aeb6e37c5f00d72790ca988b33e61d3d203"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -5935,9 +5935,9 @@ dependencies = [
 
 [[package]]
 name = "stoffelmpc-network"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74a903efb1d7c87eb71a9bc11367dd04efbdc375b66366bcb21e506848f2e041"
+checksum = "da9d4e7f12f537074c782e44ac0ffd582e3272df2a7364ed7741970d7d7dff5d"
 dependencies = [
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
@@ -5957,9 +5957,9 @@ dependencies = [
 
 [[package]]
 name = "stoffelnet"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dedfe14784d0d5d9fa4a3c5c9c36b49581c43789ac44449be3ade72fa025223"
+checksum = "4008611ad5ca586b18792e99b24217219f3884a03ec3a69c1dbff6aec94d1f82"
 dependencies = [
  "ark-ff 0.5.0",
  "async-trait",

--- a/crates/stoffel-rust-sdk/Cargo.toml
+++ b/crates/stoffel-rust-sdk/Cargo.toml
@@ -25,7 +25,7 @@ opentelemetry_sdk = { version = "=0.32.1", default-features = false, features = 
 rustls = { version = "=0.23.41", default-features = false, features = ["ring"] }
 serde = { version = "=1.0.228", features = ["derive"] }
 serde_json = "=1.0.150"
-stoffelnet = "=0.1.0"
+stoffelnet = "=0.1.1"
 tempfile = "=3.27.0"
 thiserror = "=2.0.18"
 tokio = { version = "=1.52.3", features = ["rt", "sync", "time"] }
@@ -40,7 +40,7 @@ stoffel-mpc-coordinator-off-chain = "=0.1.0"
 stoffel-vm = { version = "=0.1.2", path = "../stoffel-vm" }
 stoffel-vm-runner = { version = "=0.1.2", path = "../stoffel-vm-runner" }
 stoffel-vm-types = { version = "=0.1.2", path = "../stoffel-vm-types" }
-stoffelmpc-mpc = { package = "stoffelcrypto", version = "=0.1.0" }
+stoffelmpc-mpc = { package = "stoffelcrypto", version = "=0.1.1" }
 
 [dev-dependencies]
 aes = "=0.8.4"

--- a/crates/stoffel-vm-runner/Cargo.toml
+++ b/crates/stoffel-vm-runner/Cargo.toml
@@ -19,8 +19,8 @@ stoffel-vm = { version = "=0.1.2", path = "../stoffel-vm" }
 stoffel-vm-types = { version = "=0.1.2", path = "../stoffel-vm-types" }
 stoffel-mpc-coordinator-shared = "=0.1.0"
 stoffel-mpc-coordinator-off-chain = "=0.1.0"
-stoffelmpc-mpc = { package = "stoffelcrypto", version = "=0.1.0" }
-stoffelnet = "=0.1.0"
+stoffelmpc-mpc = { package = "stoffelcrypto", version = "=0.1.1" }
+stoffelnet = "=0.1.1"
 ark-bls12-381 = "=0.5.0"
 ark-bn254 = "=0.5.0"
 ark-curve25519 = "=0.5.0"

--- a/crates/stoffel-vm/Cargo.toml
+++ b/crates/stoffel-vm/Cargo.toml
@@ -17,8 +17,8 @@ crate-type = ["rlib", "cdylib"]
 
 [dependencies]
 libc = "=0.2.186"
-stoffelmpc-mpc = { package = "stoffelcrypto", version = "=0.1.0" }
-stoffelnet = "=0.1.0"
+stoffelmpc-mpc = { package = "stoffelcrypto", version = "=0.1.1" }
+stoffelnet = "=0.1.1"
 stoffel-vm-types = { version = "=0.1.2", path = "../stoffel-vm-types" }
 alloy = "=1.8.3"
 alloy-primitives = "=1.6.0"

--- a/crates/stoffel-vm/src/net/mpc/avss/shares.rs
+++ b/crates/stoffel-vm/src/net/mpc/avss/shares.rs
@@ -30,6 +30,21 @@ pub(super) struct AvssG2ExpContribution {
     pub(super) partial_point: Vec<u8>,
 }
 
+/// Verify a Feldman share against its own embedded evaluation id.
+///
+/// `stoffelcrypto` 0.1.1 added an `expected_id` argument to
+/// [`verify_feldman`] so protocol code can bind a share to the party that
+/// is supposed to hold it. The helpers in this module operate on shares whose
+/// origin is already fixed by the caller (the local share, or peer shares whose
+/// commitments must match the local ones), so we bind to the id carried in the
+/// share itself, preserving the pre-0.1.1 semantics.
+pub(super) fn verify_feldman_self<F: FftField, G: CurveGroup<ScalarField = F>>(
+    share: &FeldmanShamirShare<F, G>,
+) -> bool {
+    let expected_id = share.feldmanshare.id;
+    verify_feldman(share.clone(), expected_id)
+}
+
 impl<F, G> AvssMpcEngine<F, G>
 where
     F: FftField + PrimeField + UniformRand + Send + Sync + 'static,
@@ -147,7 +162,7 @@ where
                     tracing::warn!("wait_for_share: drain_rbc_output failed: {e:?}");
                 }
                 let shares = node.share_gen_avss.avss.shares.lock().await;
-                if let Some(Some(share_vec)) = shares.get(&session_id) {
+                if let Some((_, Some(share_vec))) = shares.get(&session_id) {
                     if let Some(share) = share_vec.first() {
                         return Ok(share.clone());
                     }
@@ -186,7 +201,7 @@ where
                 let shares = node.share_gen_avss.avss.shares.lock().await;
                 let stored = self.stored_shares.lock().await;
 
-                for share_vec in shares.values().flatten() {
+                for share_vec in shares.values().filter_map(|(_, v)| v.as_ref()) {
                     if let Some(share) = share_vec.first() {
                         let already_stored = stored
                             .values()
@@ -368,7 +383,7 @@ where
         generator: G,
         partial_point: G,
     ) -> Result<Vec<u8>, String> {
-        if !verify_feldman(share.clone()) {
+        if !verify_feldman_self(share) {
             return Err(
                 "AVSS open-in-exponent local Feldman share failed commitment verification"
                     .to_string(),
@@ -471,7 +486,7 @@ where
         context: &str,
     ) -> Result<Vec<(usize, Vec<u8>)>, String> {
         let expected_share = Self::decode_feldman_share(expected_share_bytes)?;
-        if !verify_feldman(expected_share.clone()) {
+        if !verify_feldman_self(&expected_share) {
             return Err(format!(
                 "{context}: local Feldman share failed commitment verification"
             ));
@@ -563,7 +578,7 @@ where
         use ark_ec::{pairing::Pairing, PrimeGroup};
 
         let expected_share = Self::decode_feldman_share(expected_share_bytes)?;
-        if !verify_feldman(expected_share.clone()) {
+        if !verify_feldman_self(&expected_share) {
             return Err(format!(
                 "{context}: local Feldman share failed commitment verification"
             ));
@@ -708,7 +723,7 @@ where
             .checked_add(1)
             .ok_or_else(|| format!("{context}: valid contribution count overflowed"))?;
 
-        if !verify_feldman(expected_share.clone()) {
+        if !verify_feldman_self(&expected_share) {
             return Err(format!(
                 "{context}: local Feldman share failed commitment verification"
             ));
@@ -724,7 +739,7 @@ where
                 continue;
             }
 
-            if verify_feldman(share.clone()) {
+            if verify_feldman_self(&share) {
                 verified.push(share);
                 if verified.len() == required_valid {
                     break;

--- a/crates/stoffel-vm/src/net/mpc/avss/tests.rs
+++ b/crates/stoffel-vm/src/net/mpc/avss/tests.rs
@@ -1,3 +1,4 @@
+use super::shares::verify_feldman_self;
 use super::*;
 use crate::net::curve::SupportedMpcField;
 use crate::net::mpc_engine::{DurableIdentityDigest, MpcEngine};
@@ -9,7 +10,6 @@ use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_std::test_rng;
 use std::sync::Arc;
 use stoffel_vm_types::core_types::{ClearShareValue, ShareType, F64};
-use stoffelmpc_mpc::common::share::avss::verify_feldman;
 use stoffelnet::transports::quic::QuicNetworkManager;
 
 #[test]
@@ -65,7 +65,7 @@ fn upstream_ransha_commitment_transform_produces_verifiable_ed25519_shares() {
     }
 
     for share in &computed[2 * t..] {
-        assert!(verify_feldman(share.clone()));
+        assert!(verify_feldman_self(share));
     }
 }
 
@@ -164,7 +164,7 @@ fn test_feldman_verification() {
             FeldmanShamirShare::new(y, i, t, commitments.clone()).expect("Failed to create share");
 
         assert!(
-            verify_feldman(share.clone()),
+            verify_feldman_self(&share),
             "Feldman verification failed for party {}",
             i
         );
@@ -485,7 +485,7 @@ where
         assert_eq!(share.feldmanshare.id, decoded.feldmanshare.id);
         assert_eq!(share.feldmanshare.degree, decoded.feldmanshare.degree);
         assert_eq!(share.feldmanshare.share, decoded.feldmanshare.share);
-        assert!(verify_feldman(decoded));
+        assert!(verify_feldman_self(&decoded));
     }
 
     let required = t + 1;
@@ -709,7 +709,7 @@ fn avss_open_reconstruction_rejects_non_verifiable_local_feldman_share() {
     corrupted_local.commitments = vec![G1::generator(); t + 1];
 
     assert!(
-        !verify_feldman(corrupted_local.clone()),
+        !verify_feldman_self(&corrupted_local),
         "test setup should model a local Feldman share with invalid commitments"
     );
 
@@ -1087,11 +1087,11 @@ async fn test_avss_input_share_is_local_constant_sharing() {
         "parties evaluate at distinct share ids"
     );
     assert!(
-        stoffelmpc_mpc::common::share::avss::verify_feldman(s0.clone()),
+        verify_feldman_self(&s0),
         "constant share must pass Feldman verification"
     );
     assert!(
-        stoffelmpc_mpc::common::share::avss::verify_feldman(s1.clone()),
+        verify_feldman_self(&s1),
         "constant share must pass Feldman verification"
     );
 

--- a/crates/stoffel-vm/src/net/share_algebra/tests.rs
+++ b/crates/stoffel-vm/src/net/share_algebra/tests.rs
@@ -98,7 +98,7 @@ fn feldman_linear_local_ops_preserve_verifiable_commitments() {
         &add_share_for_curve(MpcCurveConfig::Bls12_381, ty, &lhs_bytes, &rhs_bytes)
             .expect("add Feldman shares"),
     );
-    assert!(verify_feldman(added.clone()));
+    assert!(verify_feldman(added.clone(), added.feldmanshare.id));
     assert_eq!(
         added.commitments[0],
         lhs.commitments[0] + rhs.commitments[0]
@@ -112,7 +112,10 @@ fn feldman_linear_local_ops_preserve_verifiable_commitments() {
         &sub_share_for_curve(MpcCurveConfig::Bls12_381, ty, &lhs_bytes, &rhs_bytes)
             .expect("subtract Feldman shares"),
     );
-    assert!(verify_feldman(subtracted.clone()));
+    assert!(verify_feldman(
+        subtracted.clone(),
+        subtracted.feldmanshare.id
+    ));
     assert_eq!(
         subtracted.commitments[0],
         lhs.commitments[0] - rhs.commitments[0]
@@ -126,7 +129,7 @@ fn feldman_linear_local_ops_preserve_verifiable_commitments() {
         &mul_share_scalar_for_curve(MpcCurveConfig::Bls12_381, ty, &lhs_bytes, 4)
             .expect("scale Feldman share"),
     );
-    assert!(verify_feldman(scaled.clone()));
+    assert!(verify_feldman(scaled.clone(), scaled.feldmanshare.id));
     assert_eq!(scaled.commitments[0], lhs.commitments[0] * Fr::from(4u64));
     assert_eq!(scaled.commitments[1], lhs.commitments[1] * Fr::from(4u64));
 
@@ -134,7 +137,7 @@ fn feldman_linear_local_ops_preserve_verifiable_commitments() {
         &add_share_scalar_for_curve(MpcCurveConfig::Bls12_381, ty, &lhs_bytes, 9)
             .expect("add scalar to Feldman share"),
     );
-    assert!(verify_feldman(shifted.clone()));
+    assert!(verify_feldman(shifted.clone(), shifted.feldmanshare.id));
     assert_eq!(
         shifted.commitments[0],
         lhs.commitments[0] + G1Projective::generator() * Fr::from(9u64)
@@ -160,14 +163,14 @@ fn ed25519_feldman_local_ops_preserve_ed25519_commitments() {
         mul_share_field_for_curve(MpcCurveConfig::Ed25519, ty, &sk_bytes, &scalar_bytes)
             .expect("multiply Ed25519 Feldman share by field element");
     let scaled = decode_ed25519_feldman_share(&scaled_bytes);
-    assert!(verify_feldman(scaled.clone()));
+    assert!(verify_feldman(scaled.clone(), scaled.feldmanshare.id));
     assert_eq!(scaled.commitments[0], sk.commitments[0] * scalar);
     assert_eq!(scaled.commitments[1], sk.commitments[1] * scalar);
 
     let added_bytes = add_share_for_curve(MpcCurveConfig::Ed25519, ty, &nonce_bytes, &scaled_bytes)
         .expect("add Ed25519 Feldman shares");
     let added = decode_ed25519_feldman_share(&added_bytes);
-    assert!(verify_feldman(added.clone()));
+    assert!(verify_feldman(added.clone(), added.feldmanshare.id));
     assert_eq!(
         added.commitments[0],
         nonce.commitments[0] + scaled.commitments[0]

--- a/crates/stoffel-vm/src/tests/vm_turmoil_e2e.rs
+++ b/crates/stoffel-vm/src/tests/vm_turmoil_e2e.rs
@@ -714,7 +714,7 @@ impl AvssTurmoilVmEngine {
         t: usize,
     ) -> Result<Fr, String> {
         let expected_share = Self::decode_share(expected_share_bytes)?;
-        if !verify_feldman(expected_share.clone()) {
+        if !verify_feldman(expected_share.clone(), expected_share.feldmanshare.id) {
             return Err("local AVSS share failed Feldman verification".to_string());
         }
 
@@ -727,7 +727,7 @@ impl AvssTurmoilVmEngine {
             if share.commitments != expected_share.commitments {
                 continue;
             }
-            if verify_feldman(share.clone()) {
+            if verify_feldman(share.clone(), share.feldmanshare.id) {
                 verified.push(share);
                 if verified.len() == required_valid {
                     break;

--- a/docker/coordinator-wrapper/Cargo.lock
+++ b/docker/coordinator-wrapper/Cargo.lock
@@ -3305,9 +3305,9 @@ dependencies = [
 
 [[package]]
 name = "stoffelcrypto"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5dea6e2e0db0ec0ca2c66f03ea43f8054c0440c77dcc791c5e4b97d072fa7e5"
+checksum = "a66dfe8e28c5d20fb9f4864b68f67aeb6e37c5f00d72790ca988b33e61d3d203"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -3343,9 +3343,9 @@ dependencies = [
 
 [[package]]
 name = "stoffelmpc-network"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74a903efb1d7c87eb71a9bc11367dd04efbdc375b66366bcb21e506848f2e041"
+checksum = "da9d4e7f12f537074c782e44ac0ffd582e3272df2a7364ed7741970d7d7dff5d"
 dependencies = [
  "ark-ff",
  "ark-serialize",
@@ -3365,9 +3365,9 @@ dependencies = [
 
 [[package]]
 name = "stoffelnet"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dedfe14784d0d5d9fa4a3c5c9c36b49581c43789ac44449be3ade72fa025223"
+checksum = "4008611ad5ca586b18792e99b24217219f3884a03ec3a69c1dbff6aec94d1f82"
 dependencies = [
  "ark-ff",
  "async-trait",

--- a/docker/coordinator-wrapper/Cargo.toml
+++ b/docker/coordinator-wrapper/Cargo.toml
@@ -21,6 +21,6 @@ jsonrpsee = { version = "=0.26.0", features = ["full"] }
 rustls = "=0.23.41"
 stoffel-mpc-coordinator-off-chain = "=0.1.0"
 stoffel-mpc-coordinator-shared = "=0.1.0"
-stoffelmpc-mpc = { package = "stoffelcrypto", version = "=0.1.0" }
+stoffelmpc-mpc = { package = "stoffelcrypto", version = "=0.1.1" }
 tokio = { version = "=1.52.3", features = ["macros", "rt-multi-thread", "time"] }
 x509-parser = "=0.18.1"


### PR DESCRIPTION
## Summary

- Bump `stoffelcrypto` (the crates.io name for mpc-protocols) and `stoffelnet` from `=0.1.0` to `=0.1.1` in `stoffel-vm`, `stoffel-vm-runner`, `stoffel-rust-sdk`, and the docker coordinator wrapper. `stoffelmpc-network` follows to 0.1.1 via the lockfile.
- `stoffel-mpc-coordinator-shared` / `-off-chain` stay on `0.1.0` (they accept `stoffelcrypto ^0.1`). Moving them to `0.2.0` is a separate breaking bump and is not part of this PR.
- Adapt the AVSS engine to the two API changes in `stoffelcrypto` 0.1.1:
  - `verify_feldman` now takes an `expected_id`. The call sites in `net/mpc/avss/shares.rs` are associated fns with no party index in scope (and the reconstruct path only receives raw share bytes), so a `verify_feldman_self` helper binds each share to its own embedded evaluation id. This preserves the pre-0.1.1 semantics exactly; it does not add the stronger id-binding check the library now offers.
  - The AVSS share store values are now `(Instant, Option<Vec<Share>>)`; the two readers in `wait_for_share` / `await_received_share` are updated.
- CHANGELOG `[Unreleased]` entry added.

No public API of the Stoffel crates changes; this is backward compatible for downstream users.

## Verification

- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`: clean
- `cargo test --workspace --all-features` with the CI skip list: all pass
- The repo pre-commit hook (`cargo test --workspace --all-features`, no skips) also passed end to end on this tree.
- `docker/coordinator-wrapper` (outside the workspace) `cargo check`: clean

## Follow-up

- Consider threading the local party's evaluation id (`topology.party_id() + 1`) into the AVSS verification helpers so the new `expected_id` check actually binds shares to parties, as the library does internally with `ids[self.id]` / `sender_id + 1`.
- Consider bumping the coordinator crates to `0.2.0` in a separate PR.